### PR TITLE
44 implement crud operations on yearly form (#95)

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -174,26 +174,74 @@ const schema = a.schema({
     .model({
       name: a.string().required(),
       description: a.string(),
+      plan: a.hasMany("Plan", "functionalAreaId")
     })
     .authorization((allow) => [
       allow.authenticated().to(["read"]),
       allow.groups(["admin"]),
     ]),
   Project: a
-    .model({
-      name: a.string().required(),
-      location: a.string().required(),
-      projectTypeId: a.id(),
-      projectType: a.belongsTo("ProjectType", "projectTypeId"), // Belongs to ProjectType
-      clusterId: a.id(), //
-      cluster: a.belongsTo("Cluster", "clusterId"), // Belongs to Cluster
-      description: a.string(),
-    })
-    .authorization((allow) => [
-      allow.authenticated().to(["read"]),
-      allow.groups(["admin"]),
-    ]),
-    Organization: a
+  .model({
+    name: a.string().required(),
+    location: a.string().required(),
+    projectTypeId: a.id(),
+    projectType: a.belongsTo("ProjectType", "projectTypeId"), // Belongs to ProjectType
+    clusterId: a.id(), //
+    cluster: a.belongsTo("Cluster", "clusterId"), // Belongs to Cluster
+    description: a.string(),
+    yearlyPlan: a.hasMany("YearlyPlan", "projectId")
+  })
+  .authorization((allow) => [
+    allow.authenticated().to(["read"]),
+    allow.groups(["admin"]),
+  ]),
+  YearlyPlan: a
+  .model({
+    user: a.string(),
+    userId: a.string().required(),
+    projectId: a.string(),
+    project: a.belongsTo("Project", "projectId"),
+    comments: a.string(),
+    status: a.string(), 
+    year: a.string(),
+    reviewedBy: a.string(), 
+    approvedBy: a.string(),
+    quarterlyPlan: a.hasMany("QuarterlyPlan", "yearlyPlanId")
+  })
+  .authorization((allow) => [
+    allow.owner(),
+    allow.groups(["admin"]),
+  ]),
+  QuarterlyPlan: a
+  .model({
+    yearlyPlanId: a.id(),
+    yearlyPlan: a.belongsTo("YearlyPlan", "yearlyPlanId"),
+    quarter: a.integer(),
+    status: a.string(), 
+    reviewedBy: a.string(), 
+    approvedBy: a.string(),
+    plan: a.hasMany("Plan", "quarterlyPlanId")
+  })
+  .authorization((allow) => [
+    allow.owner(),
+    allow.groups(["admin"]),
+  ]),
+  Plan: a
+  .model({
+    quarterlyPlanId: a.id(),
+    quarterlyPlan: a.belongsTo("QuarterlyPlan", "quarterlyPlanId"),
+    activity: a.string().required(),
+    month: a.string().array(),
+    functionalAreaId: a.id(),
+    functionalArea: a.belongsTo("FunctionalArea", "functionalAreaId"),
+    comments: a.string(),
+    isMajorGoal: a.boolean(),
+  })
+  .authorization((allow) => [
+    allow.owner(),
+    allow.groups(["admin"]),
+  ]),
+  Organization: a
     .model({
       name: a.string().required(),
       website: a.string(),

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,21 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: "export",
-  reactStrictMode: true,
-  transpilePackages: [
-    "antd",
-    "rc-util",
-    "@babel/runtime",
-    "@ant-design/icons",
-    "@ant-design/icons-svg",
-    "rc-pagination",
-    "rc-picker",
-    "rc-tree",
-    "rc-table",
-  ],
-  images: {
-    unoptimized: true,
-  },
-};
+const nextConfig = {}
 
-export default nextConfig;
+export default nextConfig

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "antd": "5.20.5",
     "dayjs": "^1.11.13",
     "aws-amplify": "^6.6.6",
-    "dayjs": "^1.11.13",
     "docx": "^9.1.1",
     "file-saver": "^2.0.5",
     "fs": "^0.0.1-security",

--- a/src/app/yearly-form/approver-view/[id]/page.tsx
+++ b/src/app/yearly-form/approver-view/[id]/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+// import { CreateYearlyFormModal } from "@/feature/create-yearly-form";
+import { CreateYearlyFormNew } from "@/feature/create-yearly-form";
+import { MyFormsList } from "@/widgets/myforms-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+// import {  useRouter } from "next/router";
+
+import outputs from "@root/amplify_outputs.json";
+import useYearlyPlanDetails from "@/entities/yearly-form/api/yearlyplan-details";
+Amplify.configure(outputs);
+
+export default  function ApproverViewDetail({
+  params,
+}: {
+  params: { id: string }
+}) {
+  // const router = useRouter();
+  const  id  =  params.id;
+  console.log("id",id);
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  const { yearlyPlanDetail, isYearlyPlanDetailLoading, isYearlyPlanDetailError } = useYearlyPlanDetails({ condition: !!id }, id);
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: `${yearlyPlanDetail?.projectName + " [" + yearlyPlanDetail?.year + "]"}`,
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "Yearly forms",
+            href: "/yearly-form/approver-view",
+            menu: {
+              items: [
+                {
+                  key: '/yearly-form/my-forms',
+                  label: 'My forms',
+                },
+              {
+                key: '/yearly-form/reviewer-view',
+                label: 'Reviewer view',
+              },
+              {
+                key: '/yearly-form/approver-view',
+                label: 'Approver view',
+              },
+            ]
+            },
+          },
+          {
+            title: "Approver view",
+            href: "/yearly-form/approver-view",
+          },
+        ],
+        // extra: <Button onClick={() => router.push("/yearly-form/create") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+        // extra: <Button onClick={() => router.push("/yearly-form/new-my-form") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+      }}
+      content={<CreateYearlyFormNew id={id} messageApi={messageApi} type="approver"/> }
+    />
+    </>
+  );
+}

--- a/src/app/yearly-form/approver-view/page.tsx
+++ b/src/app/yearly-form/approver-view/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+// import { CreateYearlyFormModal } from "@/feature/create-yearly-form";
+import { MyFormsList } from "@/widgets/myforms-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import {  useRouter } from "next/navigation";
+
+import outputs from "@root/amplify_outputs.json";
+Amplify.configure(outputs);
+
+export default function ApproverView() {
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: "Approver view",
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "Approver view",
+            href: "/yearly-form/approver-view",
+          },
+        ],
+      }}
+      content={<MyFormsList type="approver"/>}
+    />
+    </>
+  );
+}

--- a/src/app/yearly-form/my-forms/[id]/page.tsx
+++ b/src/app/yearly-form/my-forms/[id]/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+// import { CreateYearlyFormModal } from "@/feature/create-yearly-form";
+import { CreateYearlyFormNew } from "@/feature/create-yearly-form";
+import { MyFormsList } from "@/widgets/myforms-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import useYearlyPlanDetails from "@/entities/yearly-form/api/yearlyplan-details";
+// import {  useRouter } from "next/router";
+
+import outputs from "@root/amplify_outputs.json";
+Amplify.configure(outputs);
+
+export default  function MyForms({
+  params,
+}: {
+  params: { id: string }
+}) {
+  // const router = useRouter();
+  const  id  =  params.id;
+  console.log("id",id);
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  const { yearlyPlanDetail, isYearlyPlanDetailLoading, isYearlyPlanDetailError } = useYearlyPlanDetails({ condition: !!id }, id);
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: `${yearlyPlanDetail?.projectName + " [" + yearlyPlanDetail?.year + "]"}`,
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "Yearly form",
+            href: "/yearly-form/my-forms",
+            menu: {
+              items: [
+                {
+                  key: '/yearly-form/my-forms',
+                  label: 'My forms',
+                },
+              {
+                key: '/yearly-form/reviewer-view',
+                label: 'Reviewer view',
+              },
+              {
+                key: '/yearly-form/approver-view',
+                label: 'Approver view',
+              },
+            ]
+            },
+          },
+          {
+            title: "My forms",
+            href: "/yearly-form/my-forms",
+          },
+        ],
+        // extra: <Button onClick={() => router.push("/yearly-form/create") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+        // extra: <Button onClick={() => router.push("/yearly-form/new-my-form") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+      }}
+      content={<CreateYearlyFormNew id={id} messageApi={messageApi} type="myforms"/>}
+    />
+    </>
+  );
+}

--- a/src/app/yearly-form/my-forms/page.tsx
+++ b/src/app/yearly-form/my-forms/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+// import { CreateYearlyFormModal } from "@/feature/create-yearly-form";
+import { MyFormsList } from "@/widgets/myforms-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import {  useRouter } from "next/navigation";
+
+import outputs from "@root/amplify_outputs.json";
+Amplify.configure(outputs);
+
+export default function MyForms() {
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: "My Forms",
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "My forms",
+            href: "/yearly-form/my-forms",
+          },
+        ],
+        // extra: <Button onClick={() => router.push("/yearly-form/create") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+        extra: <Button onClick={() => router.push("/yearly-form/new-my-form") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+      }}
+      content={<MyFormsList type="myforms"/>}
+    />
+    </>
+  );
+}

--- a/src/app/yearly-form/new-my-form/page.tsx
+++ b/src/app/yearly-form/new-my-form/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+import { CreateYearlyFormNew } from "@/feature/create-yearly-form";
+// import { RegionsList } from "@/widgets/regions-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import {  useRouter } from "next/navigation";
+
+import outputs from "@root/amplify_outputs.json";
+Amplify.configure(outputs);
+
+export default function MyForms() {
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: "Create Yearly Plan",
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "Create Form",
+            href: "/yearly-form/create",
+          },
+        ],
+      }}
+      content={<CreateYearlyFormNew id={undefined} messageApi={messageApi} type="createNew" />}
+    />
+    </>
+  );
+}

--- a/src/app/yearly-form/reviewer-view/[id]/page.tsx
+++ b/src/app/yearly-form/reviewer-view/[id]/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+// import { CreateYearlyFormModal } from "@/feature/create-yearly-form";
+import { CreateYearlyFormNew } from "@/feature/create-yearly-form";
+import { MyFormsList } from "@/widgets/myforms-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+// import {  useRouter } from "next/router";
+
+import outputs from "@root/amplify_outputs.json";
+import useYearlyPlanDetails from "@/entities/yearly-form/api/yearlyplan-details";
+Amplify.configure(outputs);
+
+export default  function ReviewerViewDetail({
+  params,
+}: {
+  params: { id: string }
+}) {
+  // const router = useRouter();
+  const  id  =  params.id;
+  console.log("id",id);
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  const { yearlyPlanDetail, isYearlyPlanDetailLoading, isYearlyPlanDetailError } = useYearlyPlanDetails({ condition: !!id }, id);
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: `${yearlyPlanDetail?.projectName + " [" + yearlyPlanDetail?.year + "]"}`,
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "Yearly forms",
+            href: "/yearly-form/my-forms",
+            menu: {
+              items: [
+                {
+                  key: '/yearly-form/my-forms',
+                  label: 'My forms',
+                },
+              {
+                key: '/yearly-form/reviewer-view',
+                label: 'Reviewer view',
+              },
+              {
+                key: '/yearly-form/approver-view',
+                label: 'Approver view',
+              },
+            ]
+            },
+          },
+          {
+            title: "My forms",
+            href: "/yearly-form/my-forms",
+          },
+        ],
+        // extra: <Button onClick={() => router.push("/yearly-form/create") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+        // extra: <Button onClick={() => router.push("/yearly-form/new-my-form") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+      }}
+      content={<CreateYearlyFormNew id={id} messageApi={messageApi} type="reviewer"/>}
+    />
+    </>
+  );
+}

--- a/src/app/yearly-form/reviewer-view/page.tsx
+++ b/src/app/yearly-form/reviewer-view/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Amplify } from "aws-amplify";
+
+import { message } from "antd";
+import Page from "@/shared/ui/page/ui/Page";
+// import { CreateYearlyFormModal } from "@/feature/create-yearly-form";
+import { MyFormsList } from "@/widgets/myforms-list";
+import { Button, Modal } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import {  useRouter } from "next/navigation";
+
+import outputs from "@root/amplify_outputs.json";
+Amplify.configure(outputs);
+
+export default function ReviewerView() {
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage({ maxCount: 1, duration: 2 });
+  return (
+    <>
+     {contextHolder}
+    <Page
+    showPageHeader
+      header={{
+        title: "Reviewer view",
+        breadcrumbs: [
+          {
+            title: "Home",
+            href: "/",
+          },
+
+          {
+            title: "Reviewer view",
+            href: "/yearly-form/reviewer-view",
+          },
+        ],
+        // extra: <Button onClick={() => router.push("/yearly-form/create") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+        // extra: <Button onClick={() => router.push("/yearly-form/new-my-form") } type="primary" icon={<PlusOutlined />} > Create Yearly Form  </Button>,
+      }}
+      content={<MyFormsList type="reviewer"/>}
+    />
+    </>
+  );
+}

--- a/src/entities/yearly-form/api/quarterlyplan-list.ts
+++ b/src/entities/yearly-form/api/quarterlyplan-list.ts
@@ -1,0 +1,89 @@
+import { getCurrentUser } from 'aws-amplify/auth';
+import useSWR, { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@root/amplify/data/resource";
+
+import type { QuarterlyPlan } from "../config/types";
+
+interface FetchOptions {
+  condition: boolean;
+}
+
+interface ApiResponse {
+  QuarterlyPlanList: QuarterlyPlan[];
+}
+
+export default function useQuarterlyPlanList({ condition = true }: FetchOptions, id: string|undefined) {
+  const client = generateClient<Schema>();
+
+
+
+  const fetcher = async () => {
+    const { username, userId, signInDetails } = await getCurrentUser();
+    console.log("User details", username);
+    const response = await client.models.QuarterlyPlan.list({
+      filter: {
+        yearlyPlanId: { eq: id },
+      },
+    });
+    if (response?.data) {
+      console.log("The complete response", response, response.data);
+      const quarterlyPlans = await Promise.all(
+        response.data.map(async (quarterlyPlan) => {
+          return {
+            approvedBy: quarterlyPlan.approvedBy ?? "",
+            quarter: quarterlyPlan.quarter ?? 0,
+            yearlyPlanId: quarterlyPlan.yearlyPlanId ?? "",
+            id: quarterlyPlan.id ?? "",
+            reviewedBy: quarterlyPlan.reviewedBy ?? "",
+            status: quarterlyPlan.status ?? "",
+            updatedAt: quarterlyPlan.updatedAt ?? "",
+          };
+        })
+      );
+
+      const apiResponse: ApiResponse = {
+        QuarterlyPlanList: quarterlyPlans
+      };
+
+      return apiResponse;
+    }
+    return null;
+  };
+
+
+  const { data, isLoading, error } = useSWR(
+    condition ? ["api/quarterlyPlanList"] : null,
+    fetcher,
+    {
+      keepPreviousData: true,
+    }
+  );
+
+  // const reloadYearlyPlansList = () => {
+  //   mutate(
+  //     (keys) =>
+  //       Array.isArray(keys) &&
+  //       keys.some((item) => item.startsWith("api/regions")),
+  //     undefined,
+  //     {
+  //       revalidate: true,
+  //     },
+  //   );
+  // };
+
+  // const yearlyPlansData = data?.YearlyPlanDetails?.map((yearlyPlan, index) => ({
+  //   key: index,
+  //   id: yearlyPlan.id,
+  //   project: yearlyPlan.project,
+  //   year: yearlyPlan.year,
+  //   status: yearlyPlan.status,
+  //   comments: yearlyPlan.comments,
+  // }));
+  return {
+    quarterlyPlanList: data?.QuarterlyPlanList,
+    isQuarterlyPlanListLoading: isLoading,
+    isQuarterlyPlanListError: error,
+    // reloadRegionsList
+  };
+}

--- a/src/entities/yearly-form/api/yearlyplan-details.ts
+++ b/src/entities/yearly-form/api/yearlyplan-details.ts
@@ -1,0 +1,82 @@
+import { getCurrentUser } from 'aws-amplify/auth';
+import useSWR, { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@root/amplify/data/resource";
+
+import type { YearlyPlanDetails } from "../config/types";
+
+interface FetchOptions {
+  condition: boolean;
+}
+
+interface ApiResponse {
+  YearlyPlanDetails: YearlyPlanDetails;
+}
+
+export default function useYearlyPlanDetails({ condition = true }: FetchOptions, id: string) {
+  const client = generateClient<Schema>();
+
+
+
+  const fetcher = async () => {
+    const { username, userId, signInDetails } = await getCurrentUser();
+    console.log("User details", username);
+    const response = await client.models.YearlyPlan.get({ id: id });
+    if (response?.data) {
+
+      const yearlyPlanResp = response.data;
+      if (yearlyPlanResp?.projectId) {
+        const proectResponse = await client.models.Project.get({ id: yearlyPlanResp?.projectId });
+        const yearlyPlanDetails = {
+          id: yearlyPlanResp.id ?? "",
+          user: yearlyPlanResp.user ?? "",
+          projectName: proectResponse.data?.name ?? "",
+          year: yearlyPlanResp.year ?? "",
+        }
+        console.log("The Year plan Detail", yearlyPlanDetails);
+        const apiResponse: ApiResponse = {
+          YearlyPlanDetails: yearlyPlanDetails
+        };
+
+        return apiResponse;
+      }
+    }
+    return null;
+  };
+
+
+  const { data, isLoading, error } = useSWR(
+    condition ? ["api/yearlyPlanDetail"] : null,
+    fetcher,
+    {
+      keepPreviousData: true,
+    }
+  );
+
+  // const reloadYearlyPlansList = () => {
+  //   mutate(
+  //     (keys) =>
+  //       Array.isArray(keys) &&
+  //       keys.some((item) => item.startsWith("api/regions")),
+  //     undefined,
+  //     {
+  //       revalidate: true,
+  //     },
+  //   );
+  // };
+
+  // const yearlyPlansData = data?.YearlyPlanDetails?.map((yearlyPlan, index) => ({
+  //   key: index,
+  //   id: yearlyPlan.id,
+  //   project: yearlyPlan.project,
+  //   year: yearlyPlan.year,
+  //   status: yearlyPlan.status,
+  //   comments: yearlyPlan.comments,
+  // }));
+  return {
+    yearlyPlanDetail: data?.YearlyPlanDetails,
+    isYearlyPlanDetailLoading: isLoading,
+    isYearlyPlanDetailError: error,
+    // reloadRegionsList
+  };
+}

--- a/src/entities/yearly-form/api/yearlyplan-full.ts
+++ b/src/entities/yearly-form/api/yearlyplan-full.ts
@@ -1,0 +1,127 @@
+import { fetchUserAttributes, getCurrentUser } from "aws-amplify/auth";
+import useSWR from "swr";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@root/amplify/data/resource";
+
+interface FetchOptions {
+  condition: boolean;
+}
+
+interface PlanDetails {
+  id: string;
+  quarterlyPlanId: string;
+  activity: string;
+  month: string[];
+  functionalAreaId: string;
+  comments?: string;
+  isMajorGoal: boolean;
+
+}
+
+interface QuarterlyPlanDetails {
+  id: string;
+  yearlyPlanId: string;
+  status?: string;
+  reviewedBy?: string;
+  approvedBy?: string;
+  plans: PlanDetails[];
+}
+
+interface YearlyPlanDetails {
+  id: string;
+  user: string;
+  userId: string;
+  projectId?: string;
+  comments?: string;
+  status?: string;
+  year?: string;
+  reviewedBy?: string;
+  approvedBy?: string;
+  quarterlyPlans: Record<number, QuarterlyPlanDetails>; // Change: Key is quarter number
+}
+
+interface ApiResponse {
+  YearlyPlanDetails: YearlyPlanDetails;
+}
+
+export default function useYearlyPlanFullDetails({ condition = true }: FetchOptions, id: string | undefined) {
+  const client = generateClient<Schema>();
+
+  const fetcher = async (): Promise<ApiResponse | null> => {
+    if (id) {
+      const { username } = await getCurrentUser();
+      console.log("User details", username);
+
+      const response = await client.models.YearlyPlan.get({ id });
+      if (!response?.data) return null;
+
+      const yearlyPlanResp = response.data;
+
+      const yearlyPlanDetails: YearlyPlanDetails = {
+        id: yearlyPlanResp.id,
+        user: yearlyPlanResp.user ?? "",
+        userId: yearlyPlanResp.userId,
+        projectId: yearlyPlanResp.projectId ?? "",
+        comments: yearlyPlanResp.comments ?? "",
+        status: yearlyPlanResp.status ?? "",
+        year: yearlyPlanResp.year ?? "",
+        reviewedBy: yearlyPlanResp.reviewedBy ?? "",
+        approvedBy: yearlyPlanResp.approvedBy ?? "",
+        quarterlyPlans: {}, // Change: Use an object instead of an array
+      };
+
+      // Fetch Quarterly Plans
+      const quarterlyPlans = await client.models.QuarterlyPlan.list({
+        filter: { yearlyPlanId: { eq: id } },
+      });
+
+      yearlyPlanDetails.quarterlyPlans = Object.fromEntries(
+        await Promise.all(
+          (quarterlyPlans?.data || []).map(async (quarterlyPlan): Promise<[number, QuarterlyPlanDetails]> => {
+            const quarterlyPlanDetails: QuarterlyPlanDetails = {
+              id: quarterlyPlan.id,
+              yearlyPlanId: quarterlyPlan.yearlyPlanId ?? "",
+              status: quarterlyPlan.status ?? "",
+              reviewedBy: quarterlyPlan.reviewedBy ?? "",
+              approvedBy: quarterlyPlan.approvedBy ?? "",
+              plans: [],
+            };
+
+            // Fetch Plans for each Quarterly Plan
+            const plans = await client.models.Plan.list({
+              filter: { quarterlyPlanId: { eq: quarterlyPlan.id } },
+            });
+
+            quarterlyPlanDetails.plans = (plans?.data || []).map((plan): PlanDetails => ({
+              id: plan.id,
+              quarterlyPlanId: plan.quarterlyPlanId ?? "",
+              activity: plan.activity,
+              month: (plan.month || []).map((m) => m ?? ""),
+              functionalAreaId: plan.functionalAreaId ?? "",
+              comments: plan.comments ?? "",
+              isMajorGoal: plan.isMajorGoal ?? false,
+            }));
+            return [quarterlyPlan.quarter ?? 0, quarterlyPlanDetails];
+          })
+        )
+      );
+
+      console.log("The Yearly Plan Detail", yearlyPlanDetails);
+      return { YearlyPlanDetails: yearlyPlanDetails };
+    } return null;
+  };
+
+  const { data, isLoading, error } = useSWR(
+    condition ? ["api/yearlyPlanDetail", id] : null,
+    fetcher,
+    {
+      keepPreviousData: true,
+    }
+  );
+
+  return {
+    yearlyPlanDetail: data?.YearlyPlanDetails,
+    isYearlyPlanDetailLoading: isLoading,
+    isYearlyPlanDetailError: error,
+  };
+}

--- a/src/entities/yearly-form/api/yearlyplan-list.ts
+++ b/src/entities/yearly-form/api/yearlyplan-list.ts
@@ -1,0 +1,218 @@
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
+import useSWR, { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import type { Schema } from "@root/amplify/data/resource";
+
+import type { YearlyPlan } from "../config/types";
+
+interface FetchOptions {
+  condition: boolean;
+  type: string;
+}
+
+interface ApiResponse {
+  YearlyPlans: YearlyPlan[];
+}
+
+export default function useYearlyPlansList({ condition = true, type }: FetchOptions) {
+  const client = generateClient<Schema>();
+  const fetcher = async () => {
+    const { username, userId, signInDetails } = await getCurrentUser();
+    const attributes = await fetchUserAttributes();
+    console.log("User details", username);
+    console.log("Attributes", attributes);
+
+    // console.log("clusters array", arr)
+    console.log("type", type)
+
+    let response;
+    if (type === "myforms") {
+      let projectIdsByCluster: string[] = [];
+      let projectIdsByRegion: string[] = [];
+      const clusters = attributes["custom:clusters"];
+      const clustersArr = stringToArray(clusters);
+      if (clustersArr.length > 0) {
+        const projects = await client.models.Project.list({
+          filter: {
+            or: clustersArr.map(clusterId => ({ clusterId: { eq: clusterId } })),
+          },
+        })
+        projectIdsByCluster = projects?.data.map(project => project.id);
+      }
+
+
+      const regions = attributes["custom:regions"];
+      const arr = stringToArray(regions);
+      if (arr.length > 0) {
+        const clusters = await client.models.Cluster.list({
+          filter: {
+            or: arr.map(regionId => ({ regionId: { eq: regionId } })),
+          },
+        })
+        const clusterIds = clusters?.data.map(cluster => cluster.id);
+
+
+        const projects = await client.models.Project.list({
+          filter: {
+            or: clusterIds.map(clusterId => ({ clusterId: { eq: clusterId } })),
+          },
+        })
+        projectIdsByRegion = projects?.data.map(project => project.id);
+      }
+
+      const uniqueProjectIds = Array.from(new Set([...projectIdsByCluster, ...projectIdsByRegion]));
+
+      // Construct filter condition
+      let filter = {};
+
+      if (uniqueProjectIds.length > 0) {
+        filter = {
+          or: [
+            { userId: { eq: userId } },
+            ...uniqueProjectIds.map(projectId => ({ projectId: { eq: projectId } })),
+          ],
+        };
+      } else {
+        filter = { userId: { eq: userId } };
+      }
+
+      response = await client.models.YearlyPlan.list({
+        filter
+      });
+    }
+
+    if (type === "reviewer") {
+      const clusters = attributes["custom:clusters"];
+      const arr = stringToArray(clusters);
+      if (arr.length > 0) {
+        const projects = await client.models.Project.list({
+          filter: {
+            or: arr.map(clusterId => ({ clusterId: { eq: clusterId } })),
+          },
+        })
+        const projectIds = projects?.data.map(project => project.id);
+
+
+        response = await client.models.YearlyPlan.list({
+          filter: {
+            and: [
+              {
+                or: projectIds.map(projectId => ({ projectId: { eq: projectId } })),
+              },
+              { status: { eq: "waiting for review" } },
+            ],
+          },
+        });
+      }
+    }
+
+    if (type === "approver") {
+      const regions = attributes["custom:regions"];
+      const arr = stringToArray(regions);
+      if (arr.length > 0) {
+        const clusters = await client.models.Cluster.list({
+          filter: {
+            or: arr.map(regionId => ({ regionId: { eq: regionId } })),
+          },
+        })
+        const clusterIds = clusters?.data.map(cluster => cluster.id);
+
+
+        const projects = await client.models.Project.list({
+          filter: {
+            or: clusterIds.map(clusterId => ({ clusterId: { eq: clusterId } })),
+          },
+        })
+        const projectIds = projects?.data.map(project => project.id);
+
+
+        response = await client.models.YearlyPlan.list({
+          filter: {
+            and: [
+              {
+                or: projectIds.map(projectId => ({ projectId: { eq: projectId } })),
+              },
+              { status: { eq: "waiting for approval" } },
+            ],
+          },
+        });
+      }
+    }
+
+    if (response?.data) {
+      console.log("The complete response", response, response.data);
+      const yearlyPlans = await Promise.all(
+        response.data.map(async (yearlyPlan) => {
+          const projectResp = await client.models.Project.get({ id: yearlyPlan.projectId ?? "" });
+          return {
+            id: yearlyPlan.id ?? "",
+            project: projectResp.data?.name ?? "",
+            year: yearlyPlan.year ?? "",
+            status: yearlyPlan.status ?? "",
+            comments: yearlyPlan.comments ?? "",
+            user: yearlyPlan.user ?? "",
+            userId: yearlyPlan.userId ?? "",
+          };
+        })
+      );
+
+      const apiResponse: ApiResponse = {
+        YearlyPlans: yearlyPlans
+      };
+
+      return apiResponse;
+    }
+    return null;
+  };
+
+
+  const { data, isLoading, error } = useSWR(
+    condition ? ["api/yearlyPlans"] : null,
+    fetcher,
+    {
+      keepPreviousData: true,
+    }
+  );
+
+  const reloadYearlyPlansList = () => {
+    mutate(
+      (keys) =>
+        Array.isArray(keys) &&
+        keys.some((item) => item.startsWith("api/yearlyPlans")),
+      undefined,
+      {
+        revalidate: true,
+      },
+    );
+  };
+
+  function stringToArray(str: string | undefined) {
+    if (str) {
+      const cleanedStr = str.replace(/[\[\]]/g, '').trim();
+      if (!cleanedStr) {
+        return [];
+      }
+      const arr = cleanedStr.includes(',') ? cleanedStr.split(',').map(item => item.trim()) : [cleanedStr];
+      return arr;
+    }
+    else {
+      return [];
+    }
+  }
+
+  const yearlyPlansData = data?.YearlyPlans?.map((yearlyPlan, index) => ({
+    key: index,
+    id: yearlyPlan.id,
+    project: yearlyPlan.project,
+    year: yearlyPlan.year,
+    status: yearlyPlan.status,
+    comments: yearlyPlan.comments,
+    user: yearlyPlan.user,
+  }));
+  return {
+    yearlyPlansList: yearlyPlansData ?? [],
+    isYearlyPlansListLoading: isLoading,
+    isYearlyPlansListError: error,
+    reloadYearlyPlansList
+  };
+}

--- a/src/entities/yearly-form/config/columns.ts
+++ b/src/entities/yearly-form/config/columns.ts
@@ -1,0 +1,38 @@
+export const columns = [
+  {
+    title: "Id",
+    dataIndex: "id",
+    key: "id",
+    hidden: true,
+  },
+  {
+    title: "Project",
+    dataIndex: "project",
+    key: "project",
+  },
+  {
+    title: "Year",
+    dataIndex: "year",
+    key: "year",
+  },
+  {
+    title: "Project Facilitator",
+    dataIndex: "user",
+    key: "user",
+  },
+  {
+    title: "Status",
+    dataIndex: "status",
+    key: "status",
+  },
+  {
+    title: "Comments",
+    dataIndex: "comments",
+    key: "comments",
+  },
+  {
+    title: "Actions",
+    key: "actions",
+  },
+] 
+

--- a/src/entities/yearly-form/config/types.ts
+++ b/src/entities/yearly-form/config/types.ts
@@ -1,0 +1,35 @@
+export interface YearlyPlan {
+  id: string;
+  project: string;
+  year: string;
+  status: string;
+  comments: string;
+  user: string;
+}
+
+export interface YearlyPlanDetails {
+  id: string;
+  user: string;
+  projectName: string;
+  year: string;
+}
+
+export interface QuarterlyPlan {
+  approvedBy: string;
+  quarter: number;
+  yearlyPlanId: string;
+  id: string;
+  reviewedBy: string;
+  status: string;
+  updatedAt: string;
+}
+
+export interface ApiResponse {
+  $metadata: {
+    httpStatusCode: number;
+    requestId: string;
+    attempts: number;
+    totalRetryDelay: number;
+  };
+  YearlyPlans: YearlyPlan[];
+}

--- a/src/entities/yearly-form/index.ts
+++ b/src/entities/yearly-form/index.ts
@@ -1,0 +1,1 @@
+export { default as YearlyPlansList } from "./ui/YearlyPlansList"

--- a/src/entities/yearly-form/lib/generate-columns.tsx
+++ b/src/entities/yearly-form/lib/generate-columns.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { Button } from "antd";
+import styled from "@emotion/styled";
+import { Flex, Space, Typography, Popconfirm } from "antd";
+
+interface Column<T = any> {
+  key?: string | undefined;
+  title: string;
+  type?: string;
+  dataIndex?: string | number | symbol | undefined;
+  hidden?: boolean;
+  dataType?: string;
+  copyable?: boolean;
+  render?: (value: any, record: T, index: number) => React.ReactNode;
+}
+
+export default function generateColumns<T>(
+  columns: Column<any>[],
+  handleDelete: (item: T) => void,
+  handleEdit: (item: T) => void,
+  type: string
+): Column<T>[] {
+  const { Text } = Typography;
+
+  return columns.map((column) => ({
+    ...column,
+    render: (item: any) => {
+      if (column.key === "actions") {
+        return (
+          <div>
+            <Space>
+              {(type === "myforms")? (
+              <_Button type="link" onClick={() => handleEdit(item)}>
+                Edit
+              </_Button>):(
+              <_Button type="link" onClick={() => handleEdit(item)}>
+                View
+              </_Button>)}
+              {type === "myforms" && (
+                <Popconfirm
+                  placement="bottomRight"
+                  title="Are you sure you want to delete the Yearly Plan?"
+                  okText="Yes"
+                  cancelText="No"
+                  onConfirm={() => handleDelete(item)}
+                >
+                  <_Button type="link" danger>
+                    Delete
+                  </_Button>
+
+                </Popconfirm>
+              )}
+            </Space>
+          </div>
+        );
+      }
+      if (column?.type === "break") {
+        return (
+          <Flex justify="center">
+            <VerticalText>Break</VerticalText>
+          </Flex>
+        );
+      } else if (!item) {
+        return "---";
+      }
+
+      if (column?.dataType === "array") {
+        return (
+          <Flex gap="middle" vertical>
+            <Text>{item && item[0]}</Text>
+            <Text>{item && item[1]}</Text>
+          </Flex>
+        );
+      }
+      if (column?.copyable) {
+        return (
+          <_Text copyable ellipsis={{ tooltip: item }}>
+            {item}
+          </_Text>
+        );
+      } else {
+        return item;
+      }
+    },
+    ellipsis: true,
+  }));
+}
+
+export const _Text = styled(Typography.Text) <{ copyable?: boolean }>`
+  display: ${(props) => (props.copyable ? "flex !important" : "")};
+  width: 90%;
+  .ant-typography-copy {
+    margin-left: auto;
+  }
+`;
+
+const VerticalText = styled.div`
+  text-transform: uppercase;
+  letter-spacing: 3px;
+`;
+
+const _Button = styled(Button)`
+  padding: 0;
+  margin: 0;
+`;

--- a/src/entities/yearly-form/ui/YearlyPlansList.tsx
+++ b/src/entities/yearly-form/ui/YearlyPlansList.tsx
@@ -1,0 +1,25 @@
+import { columns } from "../config/columns";
+import { EntityList } from "@/shared/ui/entity-list";
+import generateColumns from "../lib/generate-columns";
+import { YearlyPlan } from "../config/types";
+
+interface YearlyPlansListProps {
+  data: YearlyPlan[];
+  isLoading: boolean;
+  type: string;
+  handleEdit: (yearlyPlan: YearlyPlan) => void;
+  handleDelete: (yearlyPlan: YearlyPlan) => void;
+}
+
+export default function YearlyPlansList({ data, isLoading, handleDelete, handleEdit, type }: YearlyPlansListProps) {
+  return (
+    <EntityList
+      rowKey="id"
+      columns={columns}
+      mapColumn={(columns): any => generateColumns(columns, handleDelete, handleEdit, type)}
+      data={data}
+      isLoading={isLoading}
+
+    />
+  );
+}

--- a/src/feature/create-functional-area/api/create-functional-area.ts
+++ b/src/feature/create-functional-area/api/create-functional-area.ts
@@ -23,7 +23,7 @@ export default function useCreateFunctionalArea() {
       name: arg.name,
       description: arg.description,
     });
-
+console.log("response", response)
     if (response?.data) {
       const newFunctionalArea = {
         id: response.data.id,

--- a/src/feature/create-functional-area/ui/CreateFunctionalAreaForm.tsx
+++ b/src/feature/create-functional-area/ui/CreateFunctionalAreaForm.tsx
@@ -45,6 +45,7 @@ const CreateFunctionalAreaForm: React.FC<CreateFunctionalAreaFormProps> = ({
           "Functional area name already in use. Please try again with a different name."
         );
       } else {
+        console.log("error", error)
         messageApi.error("Unable to create the functional area. Please try again.");
       }
     }

--- a/src/feature/create-yearly-form/api/create-plan.ts
+++ b/src/feature/create-yearly-form/api/create-plan.ts
@@ -1,0 +1,71 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+
+interface CreatePlanInput {
+  quarterlyPlanId: string,
+  activity: string,
+  month: string[],
+  functionalAreaId: string,
+  comments: string,
+  isMajorGoal: boolean,
+}
+
+interface PlanResponse {
+  id: string;
+  quarterlyPlanId: string,
+  activity: string,
+  month: string[],
+  functionalAreaId: string,
+  comments: string,
+  isMajorGoal: boolean,
+}
+
+export default function useCreatePlan() {
+  const client = generateClient<Schema>();
+
+  const { data: Plan } = useSWR("api/plan");
+
+  // Function to create a project
+  const createPlan = async (key: string, { arg }: { arg: CreatePlanInput }) => {
+
+    console.log("arg", arg)
+    const response = await client.models.Plan.create({
+
+      quarterlyPlanId: arg.quarterlyPlanId,
+      activity: arg.activity,
+      month: arg.month,
+      functionalAreaId: arg.functionalAreaId,
+      comments: arg.comments,
+      isMajorGoal: arg.isMajorGoal,
+    });
+console.log("response",response)
+    if (response?.data) {
+      const newPlan = {
+        id: response.data.id,
+        quarterlyPlanId: response.data.quarterlyPlanId,
+        activity: response.data.activity,
+        month: response.data.month,
+        functionalAreaId: response.data.functionalAreaId,
+        comments: response.data.comments,
+        isMajorGoal: response.data.isMajorGoal,
+      } as PlanResponse;
+
+      return newPlan;
+    }
+
+    throw new Error("Failed to create the  Plan");
+  };
+
+  // Use SWR Mutation to handle the creation request
+  const { trigger, data, isMutating, error } = useSWRMutation("api/create-plan", createPlan);
+
+  return {
+    createPlan: trigger,  // Function to initiate the Plan creation
+    createdPlan: data,    // The created Plan data
+    isCreatingPlan: isMutating,  // Loading state
+    createError: error,      // Error state
+  };
+}

--- a/src/feature/create-yearly-form/api/create-quarter-plan.ts
+++ b/src/feature/create-yearly-form/api/create-quarter-plan.ts
@@ -1,0 +1,57 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+
+interface CreateQuarterlyPlanInput {
+
+  yearlyPlanId: string,
+  quarter: number,
+  status: string,
+}
+
+interface QuarterlyPlanResponse {
+  id: string;
+  yearlyPlanId: string,
+  quarter: number,
+  status: string,
+}
+
+export default function useCreateQuarterlyPlan() {
+  const client = generateClient<Schema>();
+
+  const { data: quarterlyPlan } = useSWR("api/quarterlyPlan");
+
+  // Function to create a project
+  const createQuarterlyPlan = async (key: string, { arg }: { arg: CreateQuarterlyPlanInput }) => {
+    const response = await client.models.QuarterlyPlan.create({
+      yearlyPlanId: arg.yearlyPlanId,
+      quarter: arg.quarter,
+      status: arg.status,
+    });
+
+    if (response?.data) {
+      const newQuarterlyPlan = {
+        id: response.data.id,
+        yearlyPlanId: response.data.yearlyPlanId,
+        quarter: response.data.quarter,
+        status: response.data.status,
+      } as QuarterlyPlanResponse;
+
+      return newQuarterlyPlan;
+    }
+
+    throw new Error("Failed to create the Quarterly Plan");
+  };
+
+  // Use SWR Mutation to handle the creation request
+  const { trigger, data, isMutating, error } = useSWRMutation("api/create-quarterly-form", createQuarterlyPlan);
+
+  return {
+    createQuarterlyPlan: trigger,  // Function to initiate the QuarterlyPlan creation
+    createdQuarterlyPlan: data,    // The created QuarterlyPlan data
+    isCreatingQuarterlyPlan: isMutating,  // Loading state
+    createError: error,      // Error state
+  };
+}

--- a/src/feature/create-yearly-form/api/create-yearly-form.ts
+++ b/src/feature/create-yearly-form/api/create-yearly-form.ts
@@ -1,0 +1,88 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+import { message } from "antd";
+
+interface CreateYearlyPlanInput {
+  user: string;
+  userId: string;
+  projectId: string;
+  comments?: string;
+  status: string;
+  year: string;
+}
+
+interface YearlyPlanResponse {
+  id: string;
+  user: string;
+  projectId: string;
+  comments: string;
+  status: string;
+  year: string;
+  userId: string;
+}
+
+interface CustomError {
+  statusCode: number;
+  message: string;
+}
+
+export default function useCreateYearlyPlan() {
+  const client = generateClient<Schema>();
+
+  const { data: yearlyPlan } = useSWR("api/yearlyPlan");
+
+  const createYearlyPlan = async (key: string, { arg }: { arg: CreateYearlyPlanInput }) => {
+console.log("arg", arg);
+    const existingPlan = await client.models.YearlyPlan.list({
+      filter: {
+        and: [
+          { projectId: { eq: arg.projectId } },
+          { userId: { eq: arg.userId } },
+        ],
+      }
+    });
+
+    if (existingPlan?.data.length > 0) {
+      console.log("After Throw")
+      throw { statusCode: 409, message: "The yearly plan for this project already exist" } as CustomError;
+      console.log("After Throw")
+    }
+
+    const response = await client.models.YearlyPlan.create({
+      user: arg.user,
+      userId: arg.userId,
+      projectId: arg.projectId,
+      comments: arg.comments,
+      status: arg.status,
+      year: arg.year,
+    });
+    console.log("response in create-yearly-form", response)
+    if (response?.data) {
+      const newYearlyPlan = {
+        id: response.data.id,
+        user: response.data.user,
+        projectId: response.data.projectId,
+        comments: response.data.comments,
+        status: response.data.status,
+        year: response.data.year,
+        userId: response.data.userId,
+      } as YearlyPlanResponse;
+
+      return newYearlyPlan;
+    }
+
+    throw new Error("Failed to create the Yearly Plan");
+  };
+  //  Use SWR Mutation to handle the creation request
+  const { trigger, data, isMutating, error } = useSWRMutation("api/create-yearly-form", createYearlyPlan);
+
+  return {
+    createYearlyPlan: trigger,  // Function to initiate the YearlyPlan creation
+    createdYearlyPlan: data,    // The created YearlyPlan data
+    isCreatingYearlyPlan: isMutating,  // Loading state
+    createError: error as CustomError | null,      // Error state
+  };
+
+}

--- a/src/feature/create-yearly-form/api/functional-area.ts
+++ b/src/feature/create-yearly-form/api/functional-area.ts
@@ -1,0 +1,60 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWR, { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+
+interface FetchOptions {
+  condition: boolean;
+}
+
+interface ApiResponse {
+  FunctionalAreas: FunctionalArea[];
+}
+
+
+export interface FunctionalArea {
+  id: string;
+  name: string;
+  // location: String;
+}
+
+export default function useFunctionalAreaList({ condition = true }: FetchOptions) {
+
+  const client = generateClient<Schema>();
+
+
+  const fetcher = async () => {
+    const response = await client.models.FunctionalArea.list();
+    if (response?.data) {
+      const functionalAreas = await Promise.all(
+        response.data.map(async (functionalArea) => {
+          return {
+            name: functionalArea.name ?? "",
+            id: functionalArea.id ?? "",
+          };
+        })
+      );
+  
+      const apiResponse: ApiResponse = {
+        FunctionalAreas: functionalAreas
+      };
+  
+      return apiResponse;  // Return the apiResponse instead of response.data to include functionalArea
+    }
+    return null;
+  };
+  
+  
+  const { data, isLoading, error } = useSWR(
+    condition ? ["api/functionalAreas"] : null,
+    fetcher,
+    {
+      keepPreviousData: true,
+    }
+  );
+
+  return {
+    functionalAreasData: data?.FunctionalAreas,
+    isFunctionalAreaTypesDataLoading: isLoading,
+    functionalAreaTypesDataError: error,
+  };
+}

--- a/src/feature/create-yearly-form/api/project-list.ts
+++ b/src/feature/create-yearly-form/api/project-list.ts
@@ -1,0 +1,91 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWR, { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
+
+interface FetchOptions {
+  condition: boolean;
+  projectId: string ;
+}
+
+interface ApiResponse {
+  Projects: Project[];
+}
+
+
+export interface Project {
+  id: string;
+  name: string;
+  // location: String;
+}
+
+export default function useProjectList({ condition = true, projectId }: FetchOptions) {
+
+  const client = generateClient<Schema>();
+
+
+
+  const fetcher = async () => {
+    const { username, userId, signInDetails } = await getCurrentUser();
+    const attributes = await fetchUserAttributes();
+    const projects = attributes["custom:projects"];
+    const projectsArray = stringToArray(projects);
+    if (!projectsArray || projectsArray.length === 0 && projectId === "project") {
+      return { Projects: [] };
+    }else{
+      if (!projectsArray.includes(projectId)) {
+        projectsArray.push(projectId);
+      }
+    }
+    const response = await client.models.Project.list({
+      filter: {
+        or: projectsArray.map(projectId => ({ id: { eq: projectId } })),
+      },
+    });
+    if (response?.data) {
+      const projects = await Promise.all(
+        response.data.map(async (project) => {
+          return {
+            name: project.name ?? "",
+            id: project.id ?? "",
+          };
+        })
+      );
+
+      const apiResponse: ApiResponse = {
+        Projects: projects
+      };
+
+      return apiResponse;  // Return the apiResponse instead of response.data to include projectType
+    }
+    return null;
+  };
+
+
+  const { data, isLoading, error } = useSWR(
+    condition ? ["api/projectTypes"] : null,
+    fetcher,
+    {
+      keepPreviousData: true,
+    }
+  );
+
+  function stringToArray(str: string | undefined) {
+    if (str) {
+      const cleanedStr = str.replace(/[\[\]]/g, '').trim();
+      if (!cleanedStr) {
+        return [];
+      }
+      const arr = cleanedStr.includes(',') ? cleanedStr.split(',').map(item => item.trim()) : [cleanedStr];
+      return arr;
+    }
+    else {
+      return [];
+    }
+  }
+  return {
+    projectsData: data?.Projects,
+    isProjectTypesDataLoading: isLoading,
+    projectTypesDataError: error,
+  };
+}

--- a/src/feature/create-yearly-form/api/update-plan.ts
+++ b/src/feature/create-yearly-form/api/update-plan.ts
@@ -1,0 +1,72 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+
+interface UpdatePlanInput {
+  quarterlyPlanId: string,
+  activity: string,
+  month: string[],
+  functionalAreaId: string,
+  comments: string,
+  id?: string,
+  isMajorGoal: boolean,
+}
+
+interface PlanResponse {
+  id: string;
+  quarterlyPlanId: string,
+  activity: string,
+  month: string[],
+  functionalAreaId: string,
+  comments: string,
+  isMajorGoal: boolean,
+}
+
+export default function useUpdatePlan() {
+  const client = generateClient<Schema>();
+
+  const { data: Plan } = useSWR("api/updatePlan");
+
+  // Function to create a project
+  const updatePlan = async (key: string, { arg }: { arg: UpdatePlanInput }) => {
+    console.log("Arguements", arg)
+    const response = await client.models.Plan.update({
+      quarterlyPlanId: arg.quarterlyPlanId,
+      activity: arg.activity,
+      month: arg.month,
+      functionalAreaId: arg.functionalAreaId,
+      // department: arg.department,
+      comments: arg.comments,
+      id: arg.id ?? "",
+      isMajorGoal: arg.isMajorGoal ?? false,
+    });
+console.log("Response from update Plan", response)
+    if (response?.data) {
+      const newPlan = {
+        id: response.data.id,
+        quarterlyPlanId: response.data.quarterlyPlanId,
+        activity: response.data.activity,
+        month: response.data.month,
+        functionalAreaId: response.data.functionalAreaId,
+        comments: response.data.comments,
+        isMajorGoal: response.data.isMajorGoal,
+      } as PlanResponse;
+
+      return newPlan;
+    }
+
+    throw new Error("Failed to update the  Plan");
+  };
+
+  // Use SWR Mutation to handle the creation request
+  const { trigger, data, isMutating, error } = useSWRMutation("api/update-plan", updatePlan);
+
+  return {
+    updatePlan: trigger,  // Function to initiate the Plan creation
+    updatedPlan: data,    // The created Plan data
+    isUpdatingPlan: isMutating,  // Loading state
+    updateError: error,      // Error state
+  };
+}

--- a/src/feature/create-yearly-form/api/update-quarter-plan.ts
+++ b/src/feature/create-yearly-form/api/update-quarter-plan.ts
@@ -1,0 +1,61 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { mutate } from "swr";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+
+interface UpdateQuarterlyPlanInput {
+
+  yearlyPlanId: string,
+  quarter: number,
+  status: string,
+  id?: string,
+}
+
+interface QuarterlyPlanResponse {
+  id: string;
+  yearlyPlanId: string,
+  quarter: number,
+  status: string,
+}
+
+export default function useUpdateQuarterlyPlan() {
+  const client = generateClient<Schema>();
+
+  const { data: quarterlyPlan } = useSWR("api/updateQuarterlyPlan");
+
+  // Function to create a project
+  const updateQuarterlyPlan = async (key: string, { arg }: { arg: UpdateQuarterlyPlanInput }) => {
+    let response;
+    if(arg.id){
+     response = await client.models.QuarterlyPlan.update({
+      yearlyPlanId: arg.yearlyPlanId,
+      quarter: arg.quarter,
+      status: arg.status,
+      id: arg?.id,
+    });
+  }
+    if (response?.data) {
+      const newQuarterlyPlan = {
+        id: response.data.id,
+        yearlyPlanId: response.data.yearlyPlanId,
+        quarter: response.data.quarter,
+        status: response.data.status,
+      } as QuarterlyPlanResponse;
+
+      return newQuarterlyPlan;
+    }
+
+    throw new Error("Failed to update the Quarterly Plan");
+  };
+
+  // Use SWR Mutation to handle the creation request
+  const { trigger, data, isMutating, error } = useSWRMutation("api/update-quarterly-form", updateQuarterlyPlan);
+
+  return {
+    updateQuarterlyPlan: trigger,  // Function to initiate the QuarterlyPlan creation
+    updatedQuarterlyPlan: data,    // The created QuarterlyPlan data
+    isUpdatingQuarterlyPlan: isMutating,  // Loading state
+    updateError: error,      // Error state
+  };
+}

--- a/src/feature/create-yearly-form/api/update-yearly-form.ts
+++ b/src/feature/create-yearly-form/api/update-yearly-form.ts
@@ -1,0 +1,64 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+
+interface UpdateYearlyPlanInput {
+  user: string;
+  projectId: string;
+  comments?: string;
+  status: string;
+  year: string;
+  id?: string;
+}
+
+interface YearlyPlanResponse {
+  id: string;
+  user: string;
+  projectId: string;
+  comments: string;
+  status: string;
+  year: string;
+}
+
+export default function useUpdateYearlyPlan() {
+  const client = generateClient<Schema>();
+
+  const { data: yearlyPlan } = useSWR("api/updateYearlyPlan");
+
+  const updateYearlyPlan = async (key: string, { arg }: { arg: UpdateYearlyPlanInput }) => {
+    const response = await client.models.YearlyPlan.update({
+      user: arg.user,
+      projectId: arg.projectId,
+      comments: arg.comments,
+      status: arg.status,
+      year: arg.year,
+      id: arg.id ?? "",
+    });
+
+    if (response?.data) {
+      const newYearlyPlan = {
+        id: response.data.id,
+        user: response.data.user,
+        projectId: response.data.projectId,
+        comments: response.data.comments,
+        status: response.data.status,
+        year: response.data.year,
+      } as YearlyPlanResponse;
+
+      return newYearlyPlan;
+    }
+
+    throw new Error("Failed to update the Yearly Plan");
+  };
+  //  Use SWR Mutation to handle the creation request
+   const { trigger, data, isMutating, error } = useSWRMutation("api/update-yearly-form", updateYearlyPlan);
+
+   return {
+     updateYearlyPlan: trigger,  // Function to initiate the YearlyPlan creation
+     updatedYearlyPlan: data,    // The created YearlyPlan data
+     isUpdatingYearlyPlan: isMutating,  // Loading state
+     updatingError: error,      // Error state
+   };
+  
+}

--- a/src/feature/create-yearly-form/index.ts
+++ b/src/feature/create-yearly-form/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright (c) ECS FIN. All rights reserved.
+ *
+ * Unauthorized copying or reproduction of this file, in any form,
+ * including file content and design, is strictly prohibited. This source code is
+ * confidential and proprietary to ECS FIN.
+ */
+
+// export { default as CreateYearlyForm } from "./ui/CreateYearlyForm";
+export { default as CreateYearlyFormNew} from "./ui/CreateYearlyFormNew"

--- a/src/feature/create-yearly-form/ui/CreateYearlyFormNew.tsx
+++ b/src/feature/create-yearly-form/ui/CreateYearlyFormNew.tsx
@@ -1,0 +1,605 @@
+
+import { Button, Checkbox, Col, Collapse, CollapseProps, Divider, Flex, Form, Input, Modal, Row, Select, Space, Spin } from "antd";
+import Projects from "./Projects";
+import FunctionalArea from "./FunctionalArea";
+import { getCurrentUser, fetchUserAttributes } from 'aws-amplify/auth';
+import QuarterlyPlan from "./QuarterlyPlan";
+import { useState, useEffect, useRef } from "react";
+import { DeleteTwoTone } from '@ant-design/icons';
+import useCreateYearlyPlan from "../api/create-yearly-form";
+import useCreateQuarterlyPlan from "../api/create-quarter-plan";
+import useCreatePlan from "../api/create-plan";
+import { useRouter } from "next/navigation";
+import useQuarterlyPlanList from "@/entities/yearly-form/api/quarterlyplan-list";
+import useYearlyPlanFullDetails from "@/entities/yearly-form/api/yearlyplan-full";
+import useUpdateYearlyPlan from "../api/update-yearly-form";
+import useUpdateQuarterlyPlan from "../api/update-quarter-plan";
+import useUpdatePlan from "../api/update-plan";
+import useDeletePlan from "@/feature/delete-plan/delete-plan";
+import useDeleteYearlyForm from "../../delete-yearly-form/delete-yearly-form"
+import CommentModal from "@/shared/ui/comment/CommentModal";
+import { AuthUser } from "aws-amplify/auth";
+const { Panel } = Collapse;
+
+interface CreateYearlyFormNewProps {
+  // onCreateYearlyFormNewModalClose: () => void;
+  id: string | undefined,
+  type: string
+  messageApi: {
+    success: (message: string) => void;
+    error: (message: string) => void;
+  };
+}
+
+interface PlanDetails {
+  id: string;
+  quarterlyPlanId: string;
+  activity: string;
+  month: string[];
+  functionalAreaId: string;
+  department?: string;
+  comments?: string;
+  isMajorGoal: boolean;
+}
+
+interface QuarterlyPlanDetails {
+  id: string;
+  yearlyPlanId: string;
+  status?: string;
+  reviewedBy?: string;
+  approvedBy?: string;
+  plans: PlanDetails[];
+}
+
+interface YearlyPlanDetails {
+  id: string;
+  user: string;
+  userId: string
+  projectId?: string;
+  comments?: string;
+  status?: string;
+  year?: string;
+  reviewedBy?: string;
+  approvedBy?: string;
+  quarterlyPlans: Record<number, QuarterlyPlanDetails>; // Change: Key is quarter number
+}
+
+
+interface FormValues {
+  // year: string;
+  project: string | undefined;
+
+}
+
+export default function CreateYearlyFormNew({
+  messageApi, id, type
+}: CreateYearlyFormNewProps) {
+
+
+  const { createYearlyPlan, isCreatingYearlyPlan } = useCreateYearlyPlan();
+  const { createQuarterlyPlan, isCreatingQuarterlyPlan } = useCreateQuarterlyPlan();
+  const { createPlan, isCreatingPlan } = useCreatePlan();
+  const { updateYearlyPlan, isUpdatingYearlyPlan } = useUpdateYearlyPlan();
+  const { updateQuarterlyPlan, isUpdatingQuarterlyPlan } = useUpdateQuarterlyPlan();
+  const { updatePlan, isUpdatingPlan } = useUpdatePlan();
+  const { deletePlan, isDeleting } = useDeletePlan();
+  const [quarterPlans, setQuarterPlans] = useState<Record<number, QuarterlyPlanDetails>>({});
+  const [plansToDelete, setPlansToDelete] = useState<string[]>([]);
+  let currentYear: number = new Date().getFullYear();
+  let nextYear: number = currentYear + 1;
+  const [form] = Form.useForm();
+  const { Option } = Select;
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [comment, setComment] = useState<string>("");
+  const [modalVisible, setModalVisible] = useState(false);
+  const [status, setStatus] = useState("");
+  const [projectFacilitator, setProjectFacilitator] = useState("");
+  const [loggedUser, setLoggedUser] = useState("");
+
+
+  const monthsArray = [
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+    "January",
+    "February",
+    "March",
+  ];
+
+  const items: { key: number; label: string }[] = [
+    {
+      key: 1,
+      label: 'Apr - Jun',
+      // children: <QuarterlyPlan form={form} quarter={1}/>,
+    },
+    {
+      key: 2,
+      label: 'Jul - Sep',
+      // children: <QuarterlyPlan form={form} quarter={1}/>,
+    },
+    {
+      key: 3,
+      label: 'Oct - Dec',
+      // children: <QuarterlyPlan form={form} quarter={1}/>,
+    },
+    {
+      key: 4,
+      label: 'Jan - Mar',
+      // children: <QuarterlyPlan form={form} quarter={1}/>,
+    },
+  ];
+
+  const { yearlyPlanDetail, isYearlyPlanDetailLoading, isYearlyPlanDetailError } = useYearlyPlanFullDetails({ condition: !!id }, id);
+  const getFutureQuarter = () => {
+    const month = new Date().getMonth() + 1;
+
+    if (month >= 1 && month <= 3) return 1;
+    if (month >= 4 && month <= 6) return 2;
+    if (month >= 7 && month <= 9) return 3;
+    return 4;
+  };
+  useEffect(() => {
+    setUserDetails();
+    console.log("Set loading to true", id, yearlyPlanDetail)
+    if (id && yearlyPlanDetail) {
+      form.setFieldsValue({
+        year: yearlyPlanDetail.year,
+        project: yearlyPlanDetail.projectId,
+      });
+      const mappedQuarterPlans: Record<number, QuarterlyPlanDetails> = {};
+      console.log("mappedQuarterPlans")
+      Object.entries(yearlyPlanDetail.quarterlyPlans).forEach(([key, quarterData]) => {
+        const quarterKey = Number(key); // Convert key to number
+
+        // Store the entire quarterly plan object, ensuring `plans` is an array
+        mappedQuarterPlans[quarterKey] = {
+          id: quarterData.id,
+          yearlyPlanId: quarterData.yearlyPlanId,
+          status: quarterData.status,
+          reviewedBy: quarterData.reviewedBy,
+          approvedBy: quarterData.approvedBy,
+          plans: quarterData.plans.map((plan) => ({
+            id: plan.id,
+            quarterlyPlanId: plan.quarterlyPlanId,
+            activity: plan.activity,
+            month: plan.month,
+            functionalAreaId: plan.functionalAreaId,
+            comments: plan.comments,
+            isMajorGoal: plan.isMajorGoal,
+          })),
+        };
+      });
+      console.log("mappedQuarterPlans completed")
+
+      // Update state
+      setQuarterPlans(mappedQuarterPlans);
+      console.log("set quarter plans completed")
+    }
+    console.log("userId", yearlyPlanDetail?.userId)
+  }, [yearlyPlanDetail]);
+
+  const showCommentPrompt = (status: string) => {
+    setStatus(status);
+    setModalVisible(true);
+  };
+
+  const setUserDetails = async () => {
+    const attributes = await fetchUserAttributes();
+    setProjectFacilitator(attributes["given_name"] + " " + attributes["family_name"]);
+    const { username, userId, signInDetails } = await getCurrentUser();
+    setLoggedUser(userId);
+  };
+
+
+  const handleSave = async (status: string, comment: string) => {
+    try {
+      setLoading(true);
+      const { username, userId, signInDetails } = await getCurrentUser();
+
+      const formValues = form.getFieldsValue();
+
+      console.log("form details", username);
+      console.log("qaurter details", userId);
+      let yearlyPlanResp;
+      const yearlyPlanPayload = {
+        user: yearlyPlanDetail?.user ?? projectFacilitator,
+        userId: yearlyPlanDetail?.userId ?? userId,
+        projectId: formValues.project,
+        ...(comment && "" != comment && { comments: comment }),
+        status: status,
+        year: formValues.year,
+        ...(yearlyPlanDetail?.id && yearlyPlanDetail?.id !== "" && { id: yearlyPlanDetail.id })
+      }
+      try {
+        if (yearlyPlanDetail?.id && "" != yearlyPlanDetail?.id) {
+          // yearlyPlanPayload
+          console.log("yearlyPlanPayload while updating", yearlyPlanPayload)
+          yearlyPlanResp = await updateYearlyPlan(yearlyPlanPayload);
+        } else {
+          yearlyPlanResp = await createYearlyPlan(yearlyPlanPayload);
+        }
+        if (yearlyPlanResp) {
+
+          console.log("Saved/Updated Yearly Plan Id", yearlyPlanResp.id);
+        }
+      } catch (error: any) {
+        throw error;
+      }
+
+      // for (const quarter of [1, 2, 3, 4]) {
+
+      if (yearlyPlanResp) {
+        for (const quarter of [1, 2, 3, 4]) {
+          const quarterlyPlanData = quarterPlans[quarter];
+
+          if (quarterlyPlanData) {
+            const quarterlyPlanPayload = {
+              id: quarterlyPlanData.id || undefined,
+              yearlyPlanId: yearlyPlanResp.id,
+              quarter: quarter,
+              status: status,
+              ...(quarterlyPlanData?.id && quarterlyPlanData?.id !== "" && { id: quarterlyPlanData.id })
+            };
+
+            let quarterPlanResp;
+            if (quarterlyPlanData.id) {
+              quarterPlanResp = await updateQuarterlyPlan(quarterlyPlanPayload);
+            } else {
+              quarterPlanResp = await createQuarterlyPlan(quarterlyPlanPayload);
+            }
+
+            if (quarterPlanResp) {
+              for (const plan of quarterlyPlanData.plans) {
+                const planPayload = {
+                  quarterlyPlanId: quarterPlanResp.id,
+                  activity: plan.activity,
+                  month: plan.month,
+                  functionalAreaId: plan.functionalAreaId,
+                  department: plan.department ?? "",
+                  comments: plan.comments ?? "",
+                  isMajorGoal: plan.isMajorGoal ?? false,
+                  ...(plan?.id && plan?.id !== "" && { id: plan.id })
+                };
+                let planResp;
+                if (plan.id) {
+                  planResp = await updatePlan(planPayload);
+                } else {
+                  planResp = await createPlan(planPayload);
+                }
+              }
+            }
+          }
+        }
+      }
+      // }
+      if (plansToDelete.length > 0) {
+        deletePlan({ ids: plansToDelete })
+      }
+      console.log("Handle save called");
+
+      if (status === "waiting for review") {
+        messageApi.success("Yearly Plan submitted for review.");
+      } else if (status === "draft") {
+        messageApi.success("Yearly Plan saved as draft.");
+      } else if (status === "waiting for approval") {
+        messageApi.success("Yearly Plan submitted for approval.");
+      } else if (status === "approved") {
+        messageApi.success("Yearly Plan approved successfully.");
+      } else if (status === "rejected") {
+        messageApi.success("Yearly Plan has been rejected.");
+      }
+
+      if (type === "myforms") {
+        router.push("/yearly-form/my-forms");
+      } else if (type === "approver") {
+        router.push("/yearly-form/approver-view");
+      } else if (type === "reviewer") {
+        router.push("/yearly-form/reviewer-view");
+      } else {
+        router.push("/yearly-form/my-forms");
+      }
+
+
+    } catch (error: any) {
+      console.error("Error saving data:", error);
+      if (error?.statusCode === 409) {
+        messageApi.error(
+          error.message
+        );
+      } else {
+        console.log("error in updating yearlyPlan", error)
+        messageApi.error("Unable to create/update the project. Please try again.");
+      }
+      // messageApi.error("Failed to save data.");
+    } finally {
+      setLoading(false);
+
+    }
+
+
+  };
+
+  const handlePlanChange = (quarter: number, index: number, field: string, value: any) => {
+    setQuarterPlans((prev) => ({
+      ...prev,
+      [quarter]: {
+        ...prev[quarter],
+        plans: prev[quarter]?.plans.map((plan, i) =>
+          i === index ? { ...plan, [field]: value } : plan
+        ),
+      },
+    }));
+    console.log("Handle plan change called", quarterPlans);
+  };
+
+  const handleDeletePlan = (quarter: number, index: number) => {
+    setQuarterPlans((prev) => {
+      const updatedQuarterPlans = { ...prev };
+
+      if (updatedQuarterPlans[quarter] && updatedQuarterPlans[quarter].plans) {
+
+        const planToDelete = updatedQuarterPlans[quarter].plans[index]?.id;
+
+        if (planToDelete) {
+          setPlansToDelete((prevIds) => [...prevIds, planToDelete]);
+        }
+        // Filter out the plan at the specified index
+        updatedQuarterPlans[quarter] = {
+          ...updatedQuarterPlans[quarter],
+          plans: updatedQuarterPlans[quarter].plans.filter((_, i) => i !== index),
+        };
+      }
+
+      return updatedQuarterPlans;
+    });
+  };
+
+
+  // const handleDeletePlan = (quarter: number, index: number) => {
+  //   setQuarterPlans((prev) => {
+  //     const updatedQuarter = prev[quarter] || [];
+  //     updatedQuarter.splice(index, 1);
+  //     return { ...prev, [quarter]: updatedQuarter };
+  //   });
+  // };
+
+  const handleAddPlan = (quarter: number) => {
+    setQuarterPlans((prev) => ({
+      ...prev,
+      [quarter]: {
+        ...prev[quarter],
+        plans: [
+          ...(prev[quarter]?.plans || []),
+          {
+            activity: "",
+            month: [],
+            functionalAreaId: "",
+            department: "",
+            comments: "",
+          } as any
+        ],
+      },
+    }));
+  };
+
+  console.log("In create", form.getFieldValue("project"));
+  // };
+
+
+  return (
+    <div>
+      <CommentModal status={status} isOpen={modalVisible} onClose={() => setModalVisible(false)} onSave={handleSave} />
+      {/* <h1>Yearly Planning</h1> */}
+      <Form form={form} layout="horizontal" disabled={(type !== "createNew" && type !== "myforms") || (type === "myforms" && (yearlyPlanDetail?.status != "draft" && yearlyPlanDetail?.status != "rejected")) || (yearlyPlanDetail?.userId ? yearlyPlanDetail.userId !== loggedUser : false)} initialValues={{ year: `${new Date().getFullYear()}-${new Date().getFullYear() + 1}`, project: "" }}>
+        <Row gutter={24}>
+          <Col xs={8}>
+            <Form.Item
+              label="Project"
+              name="project"
+              rules={[{ required: true, message: "Project is required" }]}
+            >
+              <Projects form={form} id={form.getFieldValue("project") ?? undefined} />
+            </Form.Item>
+          </Col>
+          <Col xs={8}>
+            <Form.Item label="Project Facilitator">
+              <Input disabled value={projectFacilitator} />
+            </Form.Item>
+          </Col>
+          <Col xs={8}>
+            <Form.Item label="Year" name="year">
+              <Input disabled />
+            </Form.Item>
+          </Col>
+
+        </Row>
+        <Row gutter={24} style={{ padding: "10px" }}>
+          <Col xs={8}>
+            {yearlyPlanDetail?.comments && (
+              <div
+                style={{
+                  padding: "7px 7px 7px 0px",
+                  borderRadius: "5px"
+                }}
+              >
+                Comments: <span style={{ background: yearlyPlanDetail.status === "rejected" ? "#ffccc7" : "#f0f2f5", padding: "3px 5px", borderRadius: "3px" }}>
+                  {yearlyPlanDetail.comments}
+                </span>
+              </div>
+            )}
+          </Col>
+        </Row>
+        <>
+          {isYearlyPlanDetailLoading || loading ? (
+            <div
+              style={{
+                position: "fixed",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "rgba(255, 255, 255, 0.7)",
+                zIndex: 9999,
+              }}
+            >
+              <Spin size="large" />
+            </div>
+          ) :
+            <Collapse defaultActiveKey={getFutureQuarter()}>
+              {items.map((quarter) => (
+                <Panel header={`${quarter.label}`} key={quarter.key}>
+                  <Row gutter={24}>
+                    <Col span={1}>Sl. No</Col>
+                    <Col span={5}>Activity <span style={{ color: 'red' }}>*</span></Col>
+                    <Col span={4}>
+                      Functional Area <span style={{ color: 'red' }}>*</span>
+                    </Col>
+                    <Col span={3}>Months <span style={{ color: 'red' }}>*</span></Col>
+                    <Col span={3}>Major Goal</Col>
+                    <Col span={6}>Comments</Col>
+                    <Col span={2}></Col>
+                  </Row>
+                  <Divider></Divider>
+                  {quarterPlans[quarter.key]?.plans?.map((plan, index) => (
+                    // <div key={index} style={{ marginBottom: 16, display: "flex" }}>
+                    <Row gutter={24}>
+                      <Col span={1}>
+                        <div>{index + 1}</div>
+                      </Col>
+                      <Col span={5}>
+                        <Form.Item >
+                          <Input
+                            value={plan.activity || ""}
+                            onChange={(e) => handlePlanChange(quarter.key, index, "activity", e.target.value)}
+                          />
+                        </Form.Item>
+                      </Col>
+                      <Col span={4}>
+                        <Form.Item >
+                          <FunctionalArea handlePlanChange={handlePlanChange} quarterKey={quarter.key} index={index} functionalAreaId={plan.functionalAreaId} />
+                        </Form.Item>
+                      </Col>
+                      <Col span={3}>
+                        <Form.Item >
+                          <Select
+                            mode="multiple"
+                            value={plan.month || []}
+                            onChange={(value) => handlePlanChange(quarter.key, index, "month", value)}
+                          >
+                            {monthsArray.slice((quarter.key - 1) * 3, quarter.key * 3).map((month) => (
+                              <Option key={month} value={month}>
+                                {month}
+                              </Option>
+                            ))}
+                          </Select>
+                        </Form.Item>
+                      </Col>
+                      <Col span={3}>
+                        <Form.Item>
+                          <Checkbox
+                            checked={plan.isMajorGoal || false}
+                            onChange={(e) => handlePlanChange(quarter.key, index, "isMajorGoal", e.target.checked)}
+                          >
+                          </Checkbox>
+                        </Form.Item>
+                      </Col>
+                      <Col span={6}>
+                        <Form.Item>
+                          <Input
+                            value={plan.comments || ""}
+                            onChange={(e) => handlePlanChange(quarter.key, index, "comments", e.target.value)}
+                          />
+                        </Form.Item>
+                      </Col>
+                      <Col span={2}>
+                        {/* <Button
+                      type="primary"
+                      danger
+                      onClick={() => handleDeletePlan(quarter.key, index)}
+                      style={{ marginLeft: 16 }}
+                    > */}
+                        <DeleteTwoTone onClick={() => handleDeletePlan(quarter.key, index)} twoToneColor="#FF0000" />
+                        {/* </Button> */}
+                      </Col>
+                    </Row>
+                    // </div>
+                  ))}
+                  <Button
+                    type="dashed"
+                    onClick={() => handleAddPlan(quarter.key)}
+                    block
+                  >
+                    Add Planned Activities
+                  </Button>
+                </Panel>
+
+              ))}
+            </Collapse>}
+        </>
+
+        <Form.Item style={{ marginTop: 24 }}>
+          <Space>
+            {(type === "myforms" || type === "createNew") && (
+              <>
+                <Button type="primary" disabled={(type !== "createNew" && (yearlyPlanDetail?.status !== "draft" && yearlyPlanDetail?.status !== "rejected")) || false || (yearlyPlanDetail?.userId ? yearlyPlanDetail.userId !== loggedUser : false)} onClick={() => showCommentPrompt("draft")}>
+                  Save as Draft
+                </Button>
+                <Button type="primary" disabled={(type !== "createNew" && (yearlyPlanDetail?.status !== "draft" && yearlyPlanDetail?.status !== "rejected")) || false || (yearlyPlanDetail?.userId ? yearlyPlanDetail.userId !== loggedUser : false)} onClick={() => showCommentPrompt("waiting for review")}>
+                  Send to Review
+                </Button>
+              </>
+            )}
+
+            {type === "reviewer" && (
+              <>
+                <Button type="primary" disabled={false} onClick={() => showCommentPrompt("waiting for approval")}>
+                  Send for Approval
+                </Button>
+                <Button type="default" disabled={false} danger onClick={() => showCommentPrompt("rejected")}>
+                  Reject
+                </Button>
+              </>
+            )}
+
+            {type === "approver" && (
+              <>
+                <Button type="primary" disabled={false} onClick={() => showCommentPrompt("approved")}>
+                  Approve
+                </Button>
+                <Button type="default" disabled={false} danger onClick={() => showCommentPrompt("rejected")}>
+                  Reject
+                </Button>
+              </>
+            )}
+            <Button type="primary" disabled={false} onClick={() => {
+              if (type === "myforms") {
+                router.push("/yearly-form/my-forms");
+              } else if (type === "approver") {
+                router.push("/yearly-form/approver-view");
+              } else if (type === "reviewer") {
+                router.push("/yearly-form/reviewer-view");
+              } else {
+                router.push("/yearly-form/my-forms"); // Default fallback
+              }
+            }}>
+              Cancel
+            </Button>
+
+          </Space>
+        </Form.Item>
+      </Form>
+    </div>
+  );
+}
+
+// export default CreateYearlyFormNew;

--- a/src/feature/create-yearly-form/ui/FunctionalArea.tsx
+++ b/src/feature/create-yearly-form/ui/FunctionalArea.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import { Select } from "antd";
+import { FormInstance } from "antd/es/form";
+import useFunctionalAreaList from "../api/functional-area";
+
+interface FunctionalArea {
+  id: string | number;
+  name: string;
+}
+
+interface FunctionalAreaProps {
+  handlePlanChange: (quarter: number, index: number, field: string, value: any) => void;
+  quarterKey: number;
+  index: number;
+  functionalAreaId: string,
+}
+
+const FunctionalArea: React.FC<FunctionalAreaProps> = ({ handlePlanChange, quarterKey, index, functionalAreaId }) => {
+  const { functionalAreasData } = useFunctionalAreaList({ condition: true });
+const [selectedValue, setSelectedValue] = useState<string | undefined>(undefined);
+console.log("FunctionalAreaId", functionalAreaId);
+  useEffect(() => {
+    if (functionalAreasData) {
+      const functionalArea = functionalAreasData.find(functionalArea => functionalArea.id === functionalAreaId);
+      console.log("functionalArea",functionalArea);
+      setSelectedValue(functionalArea?.name);
+    }
+  }, [functionalAreasData, functionalAreaId]);
+
+  if (selectedValue === undefined && functionalAreaId) {
+    return null; // Or you can show a loading indicator here
+  }
+  const handleChange = (value: string | number ) => {
+
+    console.log("CHeckign the value inside Functional Area", quarterKey, index)
+    handlePlanChange(quarterKey, index, "functionalAreaId", value)
+    // form.setFieldValue(
+    //   "project",
+    //   value
+    // );
+  };
+
+  const transformFunctionalAreaData = (data?: FunctionalArea[]) => {
+    return data?.map((item) => ({
+      label: item.name, // Use "label" instead of "title" for Ant Design Select.
+      value: item.id,
+    })) || [];
+  };
+
+  return (
+    <Select
+      showSearch
+      dropdownStyle={{ maxHeight: 400, overflow: "auto" }}
+      allowClear
+      onChange={(value) => handleChange(value)}
+      options={transformFunctionalAreaData(functionalAreasData)}
+      defaultValue={selectedValue}
+    />
+  );
+};
+
+export default FunctionalArea;

--- a/src/feature/create-yearly-form/ui/Projects.tsx
+++ b/src/feature/create-yearly-form/ui/Projects.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import { Select } from "antd";
+import { FormInstance } from "antd/es/form";
+import useProjectList from "../api/project-list";
+
+interface Project {
+  id: string | number;
+  name: string;
+}
+
+interface ProjectsProps {
+  form: FormInstance;
+  id: string;
+}
+
+const Projects: React.FC<ProjectsProps> = ({ form, id }) => {
+  const { projectsData } = useProjectList({ condition: true, projectId: id });
+  const [selectedValue, setSelectedValue] = useState<string | undefined>(undefined);
+console.log("Project id", id)
+console.log("Project", selectedValue)
+  useEffect(() => {
+    if (projectsData) {
+      const project = projectsData.find(project => project.id === id);
+      setSelectedValue(project?.name);
+    }
+  }, [projectsData, id]);
+
+  if (selectedValue === undefined && id && id != "project") {
+    return null; // Or you can show a loading indicator here
+  }
+
+  const handleChange = (value: string | number ) => {
+    form.setFieldValue(
+      "project",
+      value
+    );
+  };
+
+  const transformProjectsData = (data?: Project[]) => {
+    return data?.map((item) => ({
+      label: item.name, // Use "label" instead of "title" for Ant Design Select.
+      value: item.id,
+    })) || [];
+  };
+
+  return (projectsData &&
+    <Select
+      showSearch
+      dropdownStyle={{ maxHeight: 400, overflow: "auto" }}
+      allowClear
+      onChange={(value) => handleChange(value)}
+      options={transformProjectsData(projectsData)}
+      defaultValue={selectedValue}
+    />
+  );
+};
+
+export default Projects;

--- a/src/feature/create-yearly-form/ui/QuarterlyPlan.tsx
+++ b/src/feature/create-yearly-form/ui/QuarterlyPlan.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { FormInstance } from "antd/es/form";
+import { Form, Input } from 'antd';
+
+interface QuarterlyPlanProps {
+    form: FormInstance;
+    quarter: number;
+}
+
+interface FormValues {
+    // year: string;
+    activity: string;
+    project: string;
+    functionalArea: string;
+    month: string[];
+    department: string;
+    comment: string;
+    plans: string[];
+
+}
+
+const QuarterlyPlan: React.FC<QuarterlyPlanProps> = ({ form, quarter }) => {
+    const [planForm] = Form.useForm<FormValues>();
+    return (
+        <Form form={planForm}>
+            <Form.List name="plans">
+                {(fields) => (
+                   
+                    <>
+                    
+                        {fields.map((field) => (
+                            <Form.Item
+                                {...field}
+                                label="Activity"
+                                name={[field.name, 'activity']}
+                                rules={[{ required: true, message: 'Missing activity' }]}
+                            >
+                                 
+                                <Input placeholder="test"/>
+                                {/* {{console.log("Field index: %d, Field name: %d, Field key: %d",fields,field,field.name)}} */}
+                            </Form.Item>
+                        ))
+
+                        }
+                    </>
+                )}
+
+
+            </Form.List>
+        </Form>
+    );
+};
+export default QuarterlyPlan;

--- a/src/feature/delete-plan/delete-plan.ts
+++ b/src/feature/delete-plan/delete-plan.ts
@@ -1,0 +1,44 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { generateClient } from "aws-amplify/data";
+
+interface DeletePlanInput {
+  ids: string[];
+}
+
+interface PlanResponse {
+  id: string;
+}
+
+export default function useDeletePlan() {
+  const client = generateClient<Schema>();
+
+  // Function to create a cluster
+  const deletePlan = async (key: string, { arg }: { arg: DeletePlanInput }) => {
+    try {
+      await Promise.all(arg.ids.map(id => client.models.Plan.delete({id: id})));
+      console.log("Successfully deleted all plans");
+  } catch (error) {
+      console.error("Error deleting plans:", error);
+  }
+    
+console.log("deletePlan", deletePlan);
+    // if (deletePlan) {
+    //   return {
+    //     id: response.data.id,
+    //   } as PlanResponse;
+    // }
+    // else{
+    // throw new Error("Failed to delete the plan");
+    // }
+  };
+
+  const { trigger, data, isMutating, error } = useSWRMutation("api/delete-plan", deletePlan);
+
+  return {
+    deletePlan: trigger, // Function to initiate the cluster deletion
+    deletedPlan: data,  // The deleted cluster data
+    isDeleting: isMutating, // Loading state
+    deleteError: error,     // Error state
+  };
+}

--- a/src/feature/delete-yearly-form/delete-yearly-form.ts
+++ b/src/feature/delete-yearly-form/delete-yearly-form.ts
@@ -1,0 +1,38 @@
+import type { Schema } from "@root/amplify/data/resource";
+import useSWRMutation from "swr/mutation";
+import { generateClient } from "aws-amplify/data";
+
+interface DeleteYearlyFormInput {
+  id: string;
+}
+
+interface DeleteYearlyFormResponse {
+  id: string;
+}
+
+export default function useDeleteYearlyForm() {
+  const client = generateClient<Schema>();
+
+  const deleteYearlyForm = async (key: string, { arg }: { arg: DeleteYearlyFormInput }) => {
+
+    const response = await client.models.YearlyPlan.delete({id: arg.id});
+
+    if (response?.data) {
+      return {
+        id: response.data.id,
+      } as DeleteYearlyFormResponse;
+    }
+    else{
+    throw new Error("Failed to delete the Yearly Plan");
+    }
+  };
+
+  const { trigger, data, isMutating, error } = useSWRMutation("api/delete-yearly-form", deleteYearlyForm);
+
+  return {
+    deleteYearlyForm: trigger, // Function to initiate the region deletion
+    deletedYearlyForm: data,  // The deleted region data
+    isDeleting: isMutating, // Loading state
+    deleteError: error,     // Error state
+  };
+}

--- a/src/shared/ui/comment/CommentModal.tsx
+++ b/src/shared/ui/comment/CommentModal.tsx
@@ -1,0 +1,44 @@
+import { Modal, Input, message } from "antd";
+import { useState } from "react";
+
+// Define the props for the CommentModal component
+interface CommentModalProps {
+  status: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (status: string, comment: string) => void;
+}
+
+const CommentModal: React.FC<CommentModalProps> = ({ status, isOpen, onClose, onSave }) => {
+  const [comment, setComment] = useState<string>("");
+
+  const handleSubmit = () => {
+    if (status === "rejected" && !comment.trim()) {
+      message.error("A comment is required for rejection.");
+      return;
+    }
+    onSave(status, comment);
+    setComment(""); // Reset input after submission
+    onClose(); // Close the modal
+  };
+
+  return (
+    <Modal
+      open={isOpen}
+      title={status === "rejected" ? "Provide a Reason for Rejection" : "Add Comments (Optional)"}
+      onCancel={onClose}
+      onOk={handleSubmit}
+      okText="Submit"
+      cancelText="Cancel"
+    >
+      <Input.TextArea
+        rows={4}
+        placeholder={status === "rejected" ? "Please enter a reason for rejection" : "Enter comments here (optional)"}
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+      />
+    </Modal>
+  );
+};
+
+export default CommentModal;

--- a/src/shared/ui/core/ui/Layout.tsx
+++ b/src/shared/ui/core/ui/Layout.tsx
@@ -39,7 +39,21 @@ const items = [
   },
   {
     key: "yearly-form",
-    label: <Link href="/yearly-form">Yearly form</Link>,
+    label: "Yearly Form",
+    children: [
+      {
+        key: "my-forms",
+        label: <Link href="/yearly-form/my-forms">My Forms</Link>,
+      },
+      {
+        key: "reviewer-view",
+        label: <Link href="/yearly-form/reviewer-view">Reviewer View</Link>,
+      },
+      {
+        key: "approver-view",
+        label: <Link href="/yearly-form/approver-view">Approver View</Link>,
+      },
+    ],
   },
   {
     key: "reports",

--- a/src/shared/ui/page/ui/Page.tsx
+++ b/src/shared/ui/page/ui/Page.tsx
@@ -5,7 +5,7 @@ const { Title } = Typography;
 import styled from "@emotion/styled";
 
 interface HeaderProps {
-  breadcrumbs?: { href: string; title: string }[];
+  breadcrumbs?: { href: string; title: string; menu?: { items: { key: string; label: string}[] } }[];
   title?: string;
   extra?: ReactNode;
 }

--- a/src/widgets/myforms-list/index.ts
+++ b/src/widgets/myforms-list/index.ts
@@ -1,0 +1,1 @@
+export { default as MyFormsList } from "./ui/MyFormsList";

--- a/src/widgets/myforms-list/ui/MyFormsList.tsx
+++ b/src/widgets/myforms-list/ui/MyFormsList.tsx
@@ -1,0 +1,80 @@
+import { message } from "antd";
+import { useState } from "react";
+import { YearlyPlan } from "@/entities/yearly-form/config/types";
+import useYearlyPlansList from "@/entities/yearly-form/api/yearlyplan-list";
+// import { EditYearlyPlanModal } from "@/feature/edit-region";
+import { YearlyPlansList as _YearlyPlansList } from "@/entities/yearly-form";
+import { useRouter } from "next/navigation";
+import useDeleteYearlyForm from "@/feature/delete-yearly-form/delete-yearly-form"
+
+
+export default function YearlyPlansList({ type }: { type: string }) {
+  const router = useRouter();
+  const [messageApi, contextHolder] = message.useMessage({
+    maxCount: 1,
+    duration: 2,
+  });
+  const [selectedYearlyPlan, setSelectedYearlyPlan] = useState<YearlyPlan | null>(null);
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+
+  const { yearlyPlansList, isYearlyPlansListLoading, reloadYearlyPlansList } =
+    useYearlyPlansList({
+      condition: true,
+      type,
+    });
+
+  const {deleteYearlyForm} = useDeleteYearlyForm();
+  const handleEdit = (yearlyPlan: YearlyPlan) => {
+    console.log("Data inside handleEdit", yearlyPlan);
+    setSelectedYearlyPlan(yearlyPlan);
+    // setIsEditModalVisible(true);
+    if(type === "myforms"){
+      router.push('/yearly-form/my-forms/'+yearlyPlan.id);
+    }
+    console.log("After router push")
+      
+    if(type === "approver")
+      router.push('/yearly-form/approver-view/'+yearlyPlan.id);
+    if(type === "reviewer")
+      router.push('/yearly-form/reviewer-view/'+yearlyPlan.id);
+    
+  };
+
+  // const { deleteYearlyPlan } = useDeleteYearlyPlan();
+
+  const handleDelete = async (yearlyPlan: YearlyPlan) => {
+    const payload = { id: yearlyPlan.id };
+    
+    // const payload = { id: region.id };
+    try {
+      const data = await deleteYearlyForm(payload);;
+      if (data) {
+        messageApi.success("YearlyPlan has been deleted successfully.");
+        reloadYearlyPlansList();
+      }
+    } catch (error: any) {
+      messageApi.error("Unable to delete YearlyPlan. Please try again.");
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <_YearlyPlansList
+        data={yearlyPlansList}
+        isLoading={isYearlyPlansListLoading}
+        handleEdit={handleEdit}
+        handleDelete={handleDelete}
+        type={type}
+      />
+      {/* {isEditModalVisible && selectedYearlyPlan && (
+        <EditYearlyPlanModal
+          regionDetails={selectedYearlyPlan}
+          isModalVisible={isEditModalVisible}
+          setIsModalVisible={setIsEditModalVisible}
+          messageApi={messageApi}
+        />
+      )} */}
+    </>
+  );
+}


### PR DESCRIPTION
* Test commit

* Added Yearly form

* Added yearly forms

* feature(add-listing) feature(view)
feature(edit)
feature(status-change)

* feature(delete): delete yearly plan option

* fixed issue with create new form

* For testing listing on approver and reviewer, added asterick to functional area

* Some refactoring, same user can't create different form for same project, listing issue check

* fix(delete-plan): Delete planned activity

* fix(16-projects-list): A user's project should only be listed for him for creating plan

* fix(20-3-extra-activities): 3 extra activities are added when we add a activity to an existing quarter

* fix(11):If a user doesn’t have a cluster associated still he can see the projects which are waiting for review

* fix(user-update): user update while review and approval

* fix(loadingscreen, alert): Loading screen and alert for duplicate yearlyplan for same projet

* fix(high-priority-issues): comments, waiting for review shouldn't have edit or send to review, Facilitator

* fix(edit-buttons): buttons  missing while editing

* Test

* avoided dajjs multiple entry in package.json

* fix(build-issues): rejected items disabled fixed

* fix(issue-17): Bring a cluster manger's and regional manager's projects inside my forms

* fix(issue-3): Modify the breadcrumb

* When I submitted a form for approval the alert  was for creating a plan

* project listing when no project assigned, send to review and edit option for reviewer avoided

* fix(issues): Comment modified, future quarter opens auto,

* Added major goal

* Deleted unwanted fields

---------